### PR TITLE
Allow newer versions of aiohttp

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ukhotides"
-version = "1.1.1"
+version = "1.1.2"
 description = "Python library for interfacing with the UKHO Admiralty Tidal API"
 authors = ["Ian Byrne <ian.byrne@burnsie.com.au>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.10"
-aiohttp = "3.10.11"
+aiohttp = ">= 3.10.11"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.3.3"


### PR DESCRIPTION
This aims to provide to upstream fix to the issues seen with the downstream integration and Home Assistant 2024.12 requiring aiohttp 3.11.9. I've tested the package with using aiohttp 3.11.9 and all seems good. Obviously a update to the integration is required to implement this.

This pull request includes updates to the `pyproject.toml` file to bump the version number and modify a dependency specification.

Dependency and version updates:

* Updated the project version from `1.1.1` to `1.1.2`.
* Changed the `aiohttp` dependency from a fixed version `3.10.11` to a minimum version requirement `>= 3.10.11`.